### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -14,6 +14,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  def index
+    @items = Item.all.order('created_at DESC')
+  end
+
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -6,7 +6,7 @@ class ItemsController < ApplicationController
   end
 
   def create
-    @item = Item.new(item_params)
+    @item = current_user.items.build(item_params)
     if @item.save
       redirect_to root_path # 保存に成功した場合はトップページへリダイレクト
     else

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -131,7 +131,8 @@
  <% if @items.present? %>
         <% @items.each do |item| %>
           <li class='list'>
-            <%= link_to item_path(item) do %>
+            <%# TODO: 商品詳細表示機能実装時にコメントアウトを解除 %>
+            <%# link_to item_path(item) do %>
               <div class='item-img-content'>
                 <%= image_tag item.image, class: "item-img" if item.image.attached? %>
                 <%# 商品が売れていればsold outを表示しましょう %>
@@ -150,7 +151,7 @@
                   </div>
                 </div>
               </div>
-            <% end %>
+            <%# end %>
           </li>
         <% end %>
     <% end %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,56 +128,51 @@
     </div>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
-
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
+ <% if @items.present? %>
+        <% @items.each do |item| %>
+          <li class='list'>
+            <%= link_to item_path(item) do %>
+              <div class='item-img-content'>
+                <%= image_tag item.image, class: "item-img" if item.image.attached? %>
+                <%# 商品が売れていればsold outを表示しましょう %>
+                <div class='sold-out'>
+                  <span>Sold Out!!</span>
+                </div>
+                <%# //商品が売れていればsold outを表示しましょう %>
+              </div>
+              <div class='item-info'>
+                <h3 class='item-name'><%= item.name %></h3>
+                <div class='item-price'>
+                  <span><%= item.price %>円<br><%= item.shipping_charge.name %></span>
+                  <div class='star-btn'>
+                    <%= image_tag "star.png", class:"star-icon" %>
+                    <span class='star-count'>0</span>
+                  </div>
+                </div>
+              </div>
+            <% end %>
+          </li>
         <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+    <% end %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+    <% if @items.empty? %>
       <li class='list'>
         <%= link_to '#' do %>
-        <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+          <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+          <div class='item-info'>
+            <h3 class='item-name'>商品を出品してね！</h3>
+            <div class='item-price'>
+              <span>99999999円<br>(税込み)</span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+    <% end %>
+ 
     </ul>
   </div>
   <%# /商品一覧 %>
@@ -186,4 +181,6 @@
   <span class='purchase-btn-text'>出品する</span>
   <%= image_tag 'icon_camera.png' , size: '185x50' ,class: "purchase-btn-icon" %>
 <% end %>
-<%= render "shared/footer" %>
+<%= render "shared/footer" %>   <%# 商品がある場合は表示されないようにしましょう %>
+
+  

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -181,6 +181,6 @@
   <span class='purchase-btn-text'>出品する</span>
   <%= image_tag 'icon_camera.png' , size: '185x50' ,class: "purchase-btn-icon" %>
 <% end %>
-<%= render "shared/footer" %>   <%# 商品がある場合は表示されないようにしましょう %>
+<%= render "shared/footer" %> 
 
   

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index, :new, :create, :show]
 end


### PR DESCRIPTION
## What
商品一覧表示機能の実装
- 出品された商品がトップページに一覧で表示される機能。
- 各商品には、画像、商品名、価格、配送料の負担が表示されるようにした。
- 商品が出品されていない状態では、サンプル画像と「商品を出品してね！」の文言が表示される。
- 商品を新しい順に表示することで、最新の出品商品をユーザーがすぐに確認できるようにした。

## Why
フリマアプリにおいて、ユーザーが出品された商品を一覧で見ることができる機能は必須である。この機能により、ユーザーは現在出品されている商品を効率的に閲覧でき、興味のある商品を見つけやすくなる。これは、ユーザー体験の向上に直結し、アプリの使用頻度や売上げの増加に貢献すると考えられる。

## 実装に関する動画

### 商品のデータがない場合は、ダミー商品が表示されている動画
(https://gyazo.com/f870ff503a2920809a2ff5fcd649bea2)

### 商品のデータがある場合は、商品が一覧で表示されている動画
(https://gyazo.com/a8e39c7b036f35dca8777c382175f7f8)
