### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
+  before_action :set_item, only: [:show]
 
   def new
     @item = Item.new
@@ -18,7 +19,15 @@ class ItemsController < ApplicationController
     @items = Item.all.order('created_at DESC')
   end
 
+  def show
+    # set_itemメソッドで@itemを設定
+  end
+
   private
+
+  def set_item
+    @item = Item.find(params[:id])
+  end
 
   def item_params
     params.require(:item).permit(:name, :description, :category_id, :condition_id, :shipping_charge_id, :shipping_area_id,

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -131,8 +131,7 @@
  <% if @items.present? %>
         <% @items.each do |item| %>
           <li class='list'>
-            <%# TODO: 商品詳細表示機能実装時にコメントアウトを解除 %>
-            <%# link_to item_path(item) do %>
+            <%= link_to item_path(item) do %>
               <div class='item-img-content'>
                 <%= image_tag item.image, class: "item-img" if item.image.attached? %>
                 <%# 商品が売れていればsold outを表示しましょう %>
@@ -151,7 +150,7 @@
                   </div>
                 </div>
               </div>
-            <%# end %>
+            <% end %>
           </li>
         <% end %>
     <% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,23 +23,16 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 <% if user_signed_in? && current_user.id == @item.user_id %>
     <%= link_to "商品の編集", "edit_item_path(@item)", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "item_path(@item)", data: {turbo_method: :delete}, class:"item-destroy" %>
 <% end %>
 
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
   <%# ユーザーがログインしている、かつ、ログインユーザーが出品者ではない場合に表示 %>
 <% if user_signed_in? && current_user.id != @item.user_id %>
   <%= link_to '購入画面に進む', "item_orders_path(@item", class: "item-red-btn" %>
 <% end %>
-
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
       <span><%= @item.description %></span>
@@ -107,9 +100,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -16,7 +16,7 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= @item.price %>
       </span>
       <span class="item-postage">
         <%= @item.shipping_charge.name %>
@@ -24,14 +24,14 @@
     </div>
 
 <% if user_signed_in? && current_user.id == @item.user_id %>
-    <%= link_to "商品の編集", "edit_item_path(@item)", method: :get, class: "item-red-btn" %>
+    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "item_path(@item)", data: {turbo_method: :delete}, class:"item-destroy" %>
+    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
 <% end %>
 
   <%# ユーザーがログインしている、かつ、ログインユーザーが出品者ではない場合に表示 %>
 <% if user_signed_in? && current_user.id != @item.user_id %>
-  <%= link_to '購入画面に進む', "item_orders_path(@item", class: "item-red-btn" %>
+  <%= link_to '購入画面に進む', "#", class: "item-red-btn" %>
 <% end %>
 
     <div class="item-explain-box">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image,class:"item-box-img" if @item.image.attached? %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -19,52 +19,56 @@
         ¥ 999,999,999
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.shipping_charge.name %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+<% if user_signed_in? && current_user.id == @item.user_id %>
+    <%= link_to "商品の編集", "edit_item_path(@item)", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
-
+    <%= link_to "削除", "item_path(@item)", data: {turbo_method: :delete}, class:"item-destroy" %>
+<% end %>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+  <%# ユーザーがログインしている、かつ、ログインユーザーが出品者ではない場合に表示 %>
+<% if user_signed_in? && current_user.id != @item.user_id %>
+  <%= link_to '購入画面に進む', "item_orders_path(@item", class: "item-red-btn" %>
+<% end %>
+
     <%# //商品が売れていない場合はこちらを表示しましょう %>
 
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_charge.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.shipping_area.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.days_to_ship.name %></td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
# What
商品詳細表示機能の実装

- 商品詳細ページに遷移できるようにしました。
- 商品の情報をデータベースから取得して、詳細ページに表示するようにしました。
- 出品者本人の場合のみ「商品の編集」「削除」ボタンを、それ以外のログインユーザーの場合は「購入画面に進む」ボタンを表示する条件分岐を追加しました。

# Why
- ユーザーが出品されている商品の詳細情報を確認できるようにするため。
- 出品者自身には、商品情報の編集や削除を行える機能を提供するため。
- 購入希望者が商品を購入する流れにスムーズに進めるようにするため。

# # 動画

[ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画](https://gyazo.com/1e42b550bafb6180130aedba2e823e7e)

[ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画](https://gyazo.com/8264d16db0879746205adf2d70975b45)

[ログアウト状態で、商品詳細ページへ遷移した動画](https://gyazo.com/6a9d34b553efdd159dd3f62660f0a561)