### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update]
   before_action :set_item, only: [:show, :edit, :update]
-  before_action :move_to_index, only: [:edit, :update] 
+  before_action :move_to_index, only: [:edit, :update]
 
   def new
     @item = Item.new
@@ -52,8 +52,8 @@ class ItemsController < ApplicationController
   def move_to_index
     # 売却済み商品の判断は商品購入機能実装後に追加すること
     # 自身が出品していない商品、または売却済みの商品の編集ページにアクセスしようとした場合、トップページにリダイレクト
-    if current_user.id != @item.user_id # || 売却済み判断条件
-      redirect_to root_path
-    end
+    return unless current_user.id != @item.user_id # || 売却済み判断条件
+
+    redirect_to root_path
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create]
-  before_action :set_item, only: [:show]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update]
+  before_action :move_to_index, only: [:edit, :update] 
 
   def new
     @item = Item.new
@@ -23,6 +24,19 @@ class ItemsController < ApplicationController
     # set_itemメソッドで@itemを設定
   end
 
+  def edit
+    @item = Item.find(params[:id])
+  end
+
+  def update
+    @item = Item.find(params[:id])
+    if @item.update(item_params)
+      redirect_to item_path(@item)
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def set_item
@@ -33,5 +47,13 @@ class ItemsController < ApplicationController
     params.require(:item).permit(:name, :description, :category_id, :condition_id, :shipping_charge_id, :shipping_area_id,
                                  :days_to_ship_id, :price, :image)
     # 上記のpermit内のシンボルは、フォームで扱う各入力項目のname属性に対応しています
+  end
+
+  def move_to_index
+    # 売却済み商品の判断は商品購入機能実装後に追加すること
+    # 自身が出品していない商品、または売却済みの商品の編集ページにアクセスしようとした場合、トップページにリダイレクト
+    if current_user.id != @item.user_id # || 売却済み判断条件
+      redirect_to root_path
+    end
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -24,12 +24,7 @@ class ItemsController < ApplicationController
     # set_itemメソッドで@itemを設定
   end
 
-  def edit
-    @item = Item.find(params[:id])
-  end
-
   def update
-    @item = Item.find(params[:id])
     if @item.update(item_params)
       redirect_to item_path(@item)
     else

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,7 +7,7 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item, local: true do |f| %>
     <%= render 'shared/error_messages', model: f.object %>
     <%# 商品画像 %>
     <div class="img-upload">
@@ -15,11 +15,12 @@ app/assets/stylesheets/items/new.css %>
         商品画像
         <span class="indispensable">必須</span>
       </div>
+
       <div class="click-upload">
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, class: "items-text", id: "item-image", placeholder: "商品名（必須 40文字まで）", maxlength: "40" %>
       </div>
     </div>
     <%# /商品画像 %>
@@ -29,13 +30,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :description, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -48,13 +49,13 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
-      </div>
+        <%= f.collection_select(:condition_id, Condition.all, :id, :name, {}, {class:"select-box", id:"item-condition"}) %>
+       </div>
     </div>
     <%# /商品の詳細 %>
 
@@ -69,18 +70,18 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
-        <div class="weight-bold-text">
-          発送元の地域
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
-        <div class="weight-bold-text">
-          発送までの日数
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
-      </div>
+    <%= f.collection_select(:shipping_charge_id, ShippingCharge.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+    <div class="weight-bold-text">
+      発送元の地域
+      <span class="indispensable">必須</span>
+    </div>
+    <%= f.collection_select(:shipping_area_id, ShippingArea.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
+    <div class="weight-bold-text">
+      発送までの日数
+      <span class="indispensable">必須</span>
+    </div>
+    <%= f.collection_select(:days_to_ship_id, DaysToShip.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+  </div>
     </div>
     <%# /配送について %>
 
@@ -97,7 +98,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -137,7 +138,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', item_path(@item), class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
 <% if user_signed_in? && current_user.id == @item.user_id %>
     <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", item_path(@item), method: :delete, data: {turbo_method: :delete}, class:"item-destroy" %>
+    <%= link_to "削除","#", data: {turbo_method: :delete}, class:"item-destroy" %>
 <% end %>
 
   <%# ユーザーがログインしている、かつ、ログインユーザーが出品者ではない場合に表示 %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,9 +24,9 @@
     </div>
 
 <% if user_signed_in? && current_user.id == @item.user_id %>
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+    <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+    <%= link_to "削除", item_path(@item), method: :delete, data: {turbo_method: :delete}, class:"item-destroy" %>
 <% end %>
 
   <%# ユーザーがログインしている、かつ、ログインユーザーが出品者ではない場合に表示 %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create, :show]
+  resources :items, only: [:index, :new, :create, :show, :edit, :update]
 end


### PR DESCRIPTION
# What
商品情報編集機能の実装

- `edit`アクションの追加: 商品の編集ページを表示するため。
- `update`アクションの追加: 編集された商品情報を更新するため。
- 編集画面のビューファイルの作成: ユーザーが商品情報を編集できるようにするため。
- 認証ユーザーと出品者が一致している場合のみ編集可能: 他のユーザーが商品情報を勝手に編集できないように制限するため。
- エラーハンドリングの実装: 編集内容に不備がある場合にエラーを表示し、修正を促すため。

# Why
フリマアプリにおいて、商品情報の編集機能はユーザーが商品を管理する上で必須の機能であるため。出品後に情報の誤りが見つかった場合や、商品情報を更新したい場合に、ユーザーが自由に編集できるようにすることで、アプリの利便性を向上させる。

## 動画の添付

1. **ログイン状態の出品者は、商品情報編集ページに遷移できる動画**
   (https://gyazo.com/f98bf97363c12de8a238f634c264c35b)

2. **必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画**
   (https://gyazo.com/9c30aa1fec979979c913da2036874fc2)

3. **入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画**
   (https://gyazo.com/47db73c1bf00354205541793937ddedb)

4. **何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画**
   (https://gyazo.com/1ce4c02cf6c50beff25b46925f5414ce)

5. **ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画**
   (https://gyazo.com/931023facdd225a4a2e6a246b1d7d6d7) 
   
6. **ログイン状態の場合でも、URLを直接入力して自身が出品した売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（現段階で商品購入機能の実装が済んでいる場合）**
   (動画のURL)

7. **ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画**
   (https://gyazo.com/a6c38826579845f6451fbbfc2201d65e)

8. **商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）**
   (https://gyazo.com/3ee5feac4d855598b3b8938daf664676)